### PR TITLE
perf: optimize calendar month switching by caching offday JSON and re…

### DIFF
--- a/MacCalendar/Core/CalendarManager.swift
+++ b/MacCalendar/Core/CalendarManager.swift
@@ -166,7 +166,7 @@ class CalendarManager: ObservableObject {
     }
     
     func loadCalendarDays(date: Date) async {
-        await requestAccess()
+        await requestAccessIfNeeded()
         
         // 获取月份的开始日期作为缓存键
         guard let monthStart = calendar.dateInterval(of: .month, for: date)?.start else {
@@ -180,9 +180,10 @@ class CalendarManager: ObservableObject {
         }
         
         guard authorizationStatus == .fullAccess else {
-            generateCalendarGrid(for: date, events: [:])
+            let days = await generateCalendarGrid(for: date, events: [:])
             // 缓存无事件的日历数据
-            calendarDataCache[monthStart] = self.calendarDays
+            calendarDataCache[monthStart] = days
+            self.calendarDays = days
             return
         }
         
@@ -196,13 +197,14 @@ class CalendarManager: ObservableObject {
         
         let groupedEvents = groupEventsByDay(events: events)
         
-        generateCalendarGrid(for: date, events: groupedEvents)
+        let days = await generateCalendarGrid(for: date, events: groupedEvents)
         // 缓存日历数据
-        calendarDataCache[monthStart] = self.calendarDays
+        calendarDataCache[monthStart] = days
+        self.calendarDays = days
     }
     
     func loadCalendarInfo() async {
-        if authorizationStatus == .notDetermined { await requestAccess() }
+        await requestAccessIfNeeded()
         guard authorizationStatus == .fullAccess else { return }
         
         let allEKCalendars = eventStore.calendars(for: .event)
@@ -283,16 +285,17 @@ class CalendarManager: ObservableObject {
             .store(in: &cancellables)
     }
     
-    private func requestAccess() async {
+    private func requestAccessIfNeeded() async {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        authorizationStatus = status
+        
+        guard status == .notDetermined else { return }
+        
         do {
             let granted = try await eventStore.requestFullAccessToEvents()
             authorizationStatus = granted ? .fullAccess : .denied
         } catch {
             authorizationStatus = .denied
-        }
-        
-        if authorizationStatus == .notDetermined {
-            authorizationStatus = EKEventStore.authorizationStatus(for: .event)
         }
     }
     func getDisplayName(participant: EKParticipant) -> String {
@@ -396,7 +399,7 @@ class CalendarManager: ObservableObject {
         return groupedEvents
     }
     
-    private nonisolated func generateDateGrid(for date: Date) -> [Date]? {
+    private func generateDateGrid(for date: Date) -> [Date]? {
         guard let monthInterval = calendar.dateInterval(of: .month, for: date) else { return nil }
         
         var gridDates: [Date] = []
@@ -435,7 +438,7 @@ class CalendarManager: ObservableObject {
         
         return gridDates
     }
-    private nonisolated func calculateWeekOfYear(for date: Date?) -> Int {
+    private func calculateWeekOfYear(for date: Date?) -> Int {
         guard let date = date else { return 0 }
         
         var calendar = Calendar(identifier: .gregorian)
@@ -450,74 +453,65 @@ class CalendarManager: ObservableObject {
         
         return week
     }
-    private func generateCalendarGrid(for date: Date, events: [Date: [CalendarEvent]]) {
-        // 在后台线程执行计算密集型操作
-        Task.detached { [weak self] in
-            guard let self = self else { return }
+    private func generateCalendarGrid(for date: Date, events: [Date: [CalendarEvent]]) async -> [CalendarDay] {
+        let lunarCalendar = Calendar(identifier: .chinese)
+        let lunarMonthSymbols = ["正月","二月","三月","四月","五月","六月","七月","八月","九月","十月","冬月","腊月"]
+        let lunarDaySymbols = ["初一","初二","初三","初四","初五","初六","初七","初八","初九","初十", "十一","十二","十三","十四","十五","十六","十七","十八","十九","二十", "廿一","廿二","廿三","廿四","廿五","廿六","廿七","廿八","廿九","三十"]
+        
+        guard let gridDates = generateDateGrid(for: date) else { return [] }
+        
+        var newDays: [CalendarDay] = []
+        
+        for day in gridDates {
+            let lunarDateComponents = lunarCalendar.dateComponents([.month,.day,.isLeapMonth], from: day)
+            let lunarMonth = lunarDateComponents.month ?? 1
+            let lunarDay = lunarDateComponents.day ?? 1
+            let lunarLeapMonth = lunarDateComponents.isLeapMonth
             
-            let lunarCalendar = Calendar(identifier: .chinese)
-            let lunarMonthSymbols = ["正月","二月","三月","四月","五月","六月","七月","八月","九月","十月","冬月","腊月"]
-            let lunarDaySymbols = ["初一","初二","初三","初四","初五","初六","初七","初八","初九","初十", "十一","十二","十三","十四","十五","十六","十七","十八","十九","二十", "廿一","廿二","廿三","廿四","廿五","廿六","廿七","廿八","廿九","三十"]
-            
-            guard let gridDates = self.generateDateGrid(for: date) else { return }
-            
-            var newDays: [CalendarDay] = []
-            
-            for day in gridDates {
-                let lunarDateComponents = lunarCalendar.dateComponents([.month,.day,.isLeapMonth], from: day)
-                let lunarMonth = lunarDateComponents.month ?? 1
-                let lunarDay = lunarDateComponents.day ?? 1
-                let lunarLeapMonth = lunarDateComponents.isLeapMonth
-                
-                var daysInLunarMonth = 0
-                if let range = lunarCalendar.range(of: .day, in: .month, for: day) {
-                    daysInLunarMonth = range.count
-                }
-                
-                let ganzhiYear = LunarDateHelper.getGanzhiYear(for: day)
-                let zodiac = LunarDateHelper.getZodiac(for: day)
-                let short_lunar = (lunarDay == 1) ? (lunarLeapMonth == true ? "闰" : "") + lunarMonthSymbols[lunarMonth - 1] : lunarDaySymbols[lunarDay - 1]
-                let full_lunar = "\(ganzhiYear) (\(zodiac)) \((lunarLeapMonth == true ? "闰" : "") + lunarMonthSymbols[lunarMonth - 1])\(lunarDaySymbols[lunarDay - 1])"
-                
-                let dayStart = self.calendar.startOfDay(for: day)
-                let dayEvents = events[dayStart] ?? []
-                
-                let solar_term = SolarTermHelper.getSolarTerm(for: day)
-                
-                let holidays = HolidayHelper.getHolidays(date: day, lunarMonth: lunarMonth, lunarDay: lunarDay, daysInLunarMonth: daysInLunarMonth)
-                
-                let offday = OffdayHelper.checkOffdayStatus(for: day)
-                
-                let is_today = self.calendar.isDateInToday(day)
-                
-                let is_currentMonth = self.calendar.isDate(day, equalTo: date, toGranularity: .month)
-                
-                newDays.append(CalendarDay(is_today: is_today,is_currentMonth: is_currentMonth,date: day, short_lunar: short_lunar,full_lunar: full_lunar,holidays: holidays,solar_term: solar_term,offday: offday, events: dayEvents))
+            var daysInLunarMonth = 0
+            if let range = lunarCalendar.range(of: .day, in: .month, for: day) {
+                daysInLunarMonth = range.count
             }
             
-            var _newDays :[CalendarDay] = []
-            if SettingsManager.showWeekNumber {
-                let day_groups = stride(from: 0, to: newDays.count, by: 7).map {
-                    Array(newDays[$0..<min($0 + 7, newDays.count)])
-                }
-                
-                for group in day_groups {
-                    let weekNum = self.calculateWeekOfYear(for: group.first?.date)
-                    
-                    let weekItem = CalendarDay(is_weekNumber:true,weekNumber:weekNum)
-                    
-                    _newDays.append(weekItem)
-                    _newDays.append(contentsOf: group)
-                }
-            }
-            else{
-                _newDays = newDays
-            }
+            let ganzhiYear = LunarDateHelper.getGanzhiYear(for: day)
+            let zodiac = LunarDateHelper.getZodiac(for: day)
+            let short_lunar = (lunarDay == 1) ? (lunarLeapMonth == true ? "闰" : "") + lunarMonthSymbols[lunarMonth - 1] : lunarDaySymbols[lunarDay - 1]
+            let full_lunar = "\(ganzhiYear) (\(zodiac)) \((lunarLeapMonth == true ? "闰" : "") + lunarMonthSymbols[lunarMonth - 1])\(lunarDaySymbols[lunarDay - 1])"
             
-            // 在主线程更新UI
-            await MainActor.run {
-                self.calendarDays = _newDays
-            }
+            let dayStart = Calendar.Based.startOfDay(for: day)
+            let dayEvents = events[dayStart] ?? []
+            
+            let solar_term = SolarTermHelper.getSolarTerm(for: day)
+            
+            let holidays = HolidayHelper.getHolidays(date: day, lunarMonth: lunarMonth, lunarDay: lunarDay, daysInLunarMonth: daysInLunarMonth)
+            
+            let offday = OffdayHelper.checkOffdayStatus(for: day)
+            
+            let is_today = Calendar.Based.isDateInToday(day)
+            
+            let is_currentMonth = Calendar.Based.isDate(day, equalTo: date, toGranularity: .month)
+            
+            newDays.append(CalendarDay(is_today: is_today, is_currentMonth: is_currentMonth, date: day, short_lunar: short_lunar, full_lunar: full_lunar, holidays: holidays, solar_term: solar_term, offday: offday, events: dayEvents))
         }
+        
+        var _newDays: [CalendarDay] = []
+        if SettingsManager.showWeekNumber {
+            let day_groups = stride(from: 0, to: newDays.count, by: 7).map {
+                Array(newDays[$0..<min($0 + 7, newDays.count)])
+            }
+            
+            for group in day_groups {
+                let weekNum = calculateWeekOfYear(for: group.first?.date)
+                
+                let weekItem = CalendarDay(is_weekNumber: true, weekNumber: weekNum)
+                
+                _newDays.append(weekItem)
+                _newDays.append(contentsOf: group)
+            }
+        } else {
+            _newDays = newDays
+        }
+        
+        return _newDays
     }
 }

--- a/MacCalendar/Utils/OffdayHelper.swift
+++ b/MacCalendar/Utils/OffdayHelper.swift
@@ -7,35 +7,34 @@
 
 import Foundation
 
-public class OffdayHelper{
+public class OffdayHelper {
+    private static var cache: [Int: OffdayDataResponse] = [:]
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+    
     public static func checkOffdayStatus(for date: Date) -> Bool? {
         let calendar = Calendar.current
         let year = calendar.component(.year, from: date)
-        let fileName = "\(year)"
-
-        guard let fileURL = Bundle.main.url(forResource: fileName,
-                                            withExtension: "json") else {
-            return nil
+        
+        let response: OffdayDataResponse
+        if let cached = cache[year] {
+            response = cached
+        } else {
+            let fileName = "\(year)"
+            guard let fileURL = Bundle.main.url(forResource: fileName, withExtension: "json"),
+                  let data = try? Data(contentsOf: fileURL),
+                  let decoded = try? JSONDecoder().decode(OffdayDataResponse.self, from: data) else {
+                return nil
+            }
+            cache[year] = decoded
+            response = decoded
         }
         
-        do {
-            let data = try Data(contentsOf: fileURL)
-            
-            let decodedResponse = try JSONDecoder().decode(OffdayDataResponse.self, from: data)
-            
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            let dateString = formatter.string(from: date)
-            
-            if let targetDay = decodedResponse.days.first(where: { $0.date == dateString }) {
-                return targetDay.isOffDay
-            }
-            
-            return nil
-            
-        } catch {
-            return nil
-        }
+        let dateString = formatter.string(from: date)
+        return response.days.first(where: { $0.date == dateString })?.isOffDay
     }
 }

--- a/MacCalendar/Views/UpdateAlertView.swift
+++ b/MacCalendar/Views/UpdateAlertView.swift
@@ -97,7 +97,7 @@ struct UpdateAlertView: View {
         case .updateAvailable(let version): return "发现新版本 \(version)"
         case .downloading: return "正在下载..."
         case .downloadComplete: return "下载完成"
-        case .error(let error): return "错误"
+        case .error: return "错误"
         }
     }
     


### PR DESCRIPTION
**问题：** 切换月份时，日历内容有约 1 秒以上的延迟，用户体验卡顿。

  **根因：** OffdayHelper.checkOffdayStatus() 每次调用都重新从 App Bundle 读取并解析 JSON 文件，而月历网格中约 35 天各调用一次，
  导致同一年份的 JSON 被重复读取解析 35 次。此外 Task.detached 引入了不必要的线程切换开销。

  **改动：**

  1. OffdayHelper.swift — 添加按年份的静态内存缓存
    • 同一年份的 JSON 只读取解析一次，后续从内存缓存直接查询
    • 复用 DateFormatter 实例，减少重复创建开销
  2. CalendarManager.swift — 移除 Task.detached，简化调用链
    • generateCalendarGrid 改为直接 async 返回结果，由 loadCalendarDays 统一调度
    • requestAccess 改为 requestAccessIfNeeded，仅在首次未授权时请求，避免每次切换月份都调用 EventKit 权限检查
    • 移除 nonisolated 修饰，修复 Swift 6 并发警告
  **效果：**
  • 切换月份响应从约 1 秒+ 降至几乎即时
  • 首次加载某年份 JSON 后，该年份所有月份切换均走内存缓存
  • EventKit 日历待办读取、事件缓存、日历筛选等功能完全保留，无功能损失