### PR TITLE
feat: 小组件切换到别的月份很久才还原问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Build
 build/
+.derived/
 
 # Package
 *.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# macOS
+.DS_Store
+
+# IDE
+.idea/
+
+# Build
+build/
+
+# Package
+*.dmg

--- a/Build.md
+++ b/Build.md
@@ -1,0 +1,88 @@
+# Build Guide
+
+## 环境要求
+
+- macOS 14.0+
+- Xcode 16+
+- 命令行工具：`xcode-select --install`
+
+## 快速开始
+
+```bash
+# 编译并启动
+./build.sh run
+
+# 仅编译 Debug
+./build.sh
+
+# 编译 Release 并打包 DMG
+./build.sh dmg
+```
+
+## 命令参考
+
+| 命令 | 用途 | 默认架构 |
+|---|---|---|
+| `debug` | Debug 构建 | native（当前 CPU） |
+| `release` | Release 构建（跳过签名） | universal |
+| `dmg` | Release 构建 + DMG 打包 | universal |
+| `run` | Debug 构建后启动 App | native |
+| `clean` | 清理构建产物 | — |
+| `help` | 显示帮助 | — |
+
+## 架构选项
+
+通过 `--arch` 指定目标架构：
+
+| 参数 | 说明 |
+|---|---|
+| `native` | 当前 Mac CPU 架构（arm64 或 x86_64） |
+| `universal` | 通用二进制，同时支持 Intel 和 Apple Silicon |
+| `arm64` | Apple Silicon 专用 |
+| `x86_64` | Intel 专用 |
+
+示例：
+
+```bash
+# Debug 构建通用二进制
+./build.sh debug --arch universal
+
+# Release 仅构建 arm64
+./build.sh release --arch arm64
+
+# 打包仅 Intel 的 DMG
+./build.sh dmg --arch x86_64
+```
+
+## 详细日志
+
+加 `-v` 查看完整 xcodebuild 输出：
+
+```bash
+./build.sh dmg -v
+```
+
+## 构建产物
+
+```
+build/
+├── universal/            # 通用二进制产物
+│   ├── Debug/MacCalendar.app
+│   ├── Release/MacCalendar.app
+│   └── MacCalendar.dmg   # DMG 安装包
+├── arm64/                # Apple Silicon 专用
+└── x86_64/               # Intel 专用
+```
+
+## 常见问题
+
+### 签名错误
+
+Release 构建已跳过签名（`CODE_SIGN_IDENTITY="-"`），可直接运行。如需分发，需替换为有效的 Apple 开发者证书。
+
+### 权限问题
+
+```bash
+# 首次运行 Release 构建的 App 需解除系统隔离
+xattr -cr build/universal/Release/MacCalendar.app
+```

--- a/MacCalendar/AppDelegate.swift
+++ b/MacCalendar/AppDelegate.swift
@@ -137,6 +137,26 @@ class AppDelegate: NSObject,NSApplicationDelegate, NSWindowDelegate {
         
         // 立即更新显示
         calendarIcon.updateDisplayOutput()
+
+        // 监听显示模式变化，隐藏/显示菜单栏图标
+        NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self, let button = self.statusItem.button else { return }
+                let mode = SettingsManager.displayMode
+                if mode == .hidden {
+                    button.isHidden = true
+                } else {
+                    button.isHidden = false
+                }
+            }
+            .store(in: &cancellables)
+
+        // 初始应用显示模式
+        if SettingsManager.displayMode == .hidden {
+            statusItem.button?.isHidden = true
+        }
         
         popover = NSPopover()
         popover.behavior = .transient

--- a/MacCalendar/Core/SettingsManager.swift
+++ b/MacCalendar/Core/SettingsManager.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftUI
 
 enum DisplayMode: String, CaseIterable, Identifiable {
+    case hidden = "不显示"
     case icon = "图标"
     case date = "日期"
     case time = "时间"
     case custom = "自定义"
-    
+
     var id: Self { self }
 }
 

--- a/MacCalendar/Models/CalendarIcon.swift
+++ b/MacCalendar/Models/CalendarIcon.swift
@@ -121,9 +121,12 @@ class CalendarIcon: ObservableObject {
     
     private func getUpdateInterval() -> (interval: TimeInterval, component: Calendar.Component) {
         switch SettingsManager.displayMode {
+        case .hidden:
+            return (86400, .day) // 不显示模式，天级更新即可
+
         case .icon:
             return (86400, .day) // 天级更新
-            
+
         case .time:
             return (1.0, .second) // 秒级更新
             
@@ -219,6 +222,9 @@ class CalendarIcon: ObservableObject {
         let currentDate = Date()
         
         switch SettingsManager.displayMode {
+        case .hidden:
+            displayOutput = ""
+            return
         case .icon:
             displayOutput = ""
         case .date:

--- a/MacCalendarWidget/MacCalendarWidget.swift
+++ b/MacCalendarWidget/MacCalendarWidget.swift
@@ -38,19 +38,18 @@ struct MacCalendarWidgetProvider: AppIntentTimelineProvider {
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<MacCalendarWidgetEntry> {
         let shared = SettingsManager.readFromSharedFile()
-        
+
         var entries: [MacCalendarWidgetEntry] = []
 
         let currentDate = Date()
         let calendar = Calendar.current
-        
+
         let viewingWindowMinutes: TimeInterval = 5 * 60
         let lastActionTime = shared.widgetLastUserActionTime
         let isWindowActive = lastActionTime > 0 && (currentDate.timeIntervalSince1970 - lastActionTime) < viewingWindowMinutes
-        let viewingWindowEndDate = Date(timeIntervalSince1970: lastActionTime + viewingWindowMinutes)
-        
+
         let currentOffset = shared.widgetMonthOffset
-        
+
         if isWindowActive {
             let displayDate1 = calculateDisplayDate(for: currentDate, context: context, customOffset: currentOffset)
             let calendarData1 = WidgetDataHelper.getCalendarData(for: displayDate1, today: currentDate, firstDayInWeek: shared.firstDayInWeek)
@@ -61,24 +60,33 @@ struct MacCalendarWidgetProvider: AppIntentTimelineProvider {
                 showWeekNumber: shared.showWeekNumber,
                 firstDayInWeek: shared.firstDayInWeek
             ))
-            
-            let displayDate2 = calculateDisplayDate(for: viewingWindowEndDate, context: context, customOffset: 0)
-            let calendarData2 = WidgetDataHelper.getCalendarData(for: displayDate2, today: viewingWindowEndDate, firstDayInWeek: shared.firstDayInWeek)
+
+            // Reset offset immediately so next refresh shows current month
+            var updated = shared
+            updated.widgetMonthOffset = 0
+            updated.widgetLastUserActionTime = 0
+            SettingsManager.writeToSharedFile(updated)
+
+            // Switch to current month after 5 seconds
+            // so closing & reopening the widget shows the current month
+            let switchDate = currentDate.addingTimeInterval(5)
+            let displayDate2 = calculateDisplayDate(for: switchDate, context: context, customOffset: 0)
+            let calendarData2 = WidgetDataHelper.getCalendarData(for: displayDate2, today: switchDate, firstDayInWeek: shared.firstDayInWeek)
             entries.append(MacCalendarWidgetEntry(
-                date: viewingWindowEndDate,
+                date: switchDate,
                 configuration: configuration,
                 calendarData: calendarData2,
                 showWeekNumber: shared.showWeekNumber,
                 firstDayInWeek: shared.firstDayInWeek
             ))
-            
-            return Timeline(entries: entries, policy: .after(viewingWindowEndDate))
+
+            return Timeline(entries: entries, policy: .after(switchDate))
         } else {
             var updated = shared
             updated.widgetLastUserActionTime = 0
             updated.widgetMonthOffset = 0
             SettingsManager.writeToSharedFile(updated)
-            
+
             for hourOffset in 0 ..< 24 {
                 let entryDate = calendar.date(byAdding: .hour, value: hourOffset, to: currentDate)!
                 let displayDate = calculateDisplayDate(for: entryDate, context: context, customOffset: 0)
@@ -91,7 +99,7 @@ struct MacCalendarWidgetProvider: AppIntentTimelineProvider {
                     firstDayInWeek: shared.firstDayInWeek
                 ))
             }
-            
+
             return Timeline(entries: entries, policy: .atEnd)
         }
     }

--- a/build.sh
+++ b/build.sh
@@ -110,14 +110,24 @@ DERIVED_DATA="$DERIVED_DATA/$ARCH_TAG"
 
 XCODE=$(xcode-select -p 2>/dev/null) || err "Xcode not found (xcode-select -p failed)"
 
-XCB_FLAGS=(
-    -project "$PROJECT"
-    -scheme "$SCHEME"
-    -destination 'platform=macOS'
-    "${ARCH_FLAGS[@]}"
-    SYMROOT="$BUILD_DIR"
-    OBJROOT="$DERIVED_DATA"
-)
+# -destination and -arch conflict, use one or the other
+if [ ${#ARCH_FLAGS[@]} -eq 0 ]; then
+    XCB_FLAGS=(
+        -project "$PROJECT"
+        -scheme "$SCHEME"
+        -destination 'platform=macOS'
+        SYMROOT="$BUILD_DIR"
+        OBJROOT="$DERIVED_DATA"
+    )
+else
+    XCB_FLAGS=(
+        -project "$PROJECT"
+        -scheme "$SCHEME"
+        "${ARCH_FLAGS[@]}"
+        SYMROOT="$BUILD_DIR"
+        OBJROOT="$DERIVED_DATA"
+    )
+fi
 
 # ----- Commands -----
 if [ "$CMD" = "debug" ] || [ "$CMD" = "run" ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT="$PROJECT_DIR/MacCalendar.xcodeproj"
+SCHEME="MacCalendar"
+BUILD_DIR="$PROJECT_DIR/build"
+DERIVED_DATA="$PROJECT_DIR/.derived"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [command] [options]
+
+Commands:
+  debug         Build Debug (default)
+  release       Build Release (unsigned)
+  dmg           Build Release + package .dmg
+  run           Build Debug and start the app
+  clean         Clean build folder
+  help          Show this help
+
+Options:
+  --arch native     Build for current CPU only (default for debug)
+  --arch universal  Build universal binary (default for release/dmg)
+  -v, --verbose     Show full xcodebuild output
+
+Examples:
+  ./build.sh debug --arch universal
+  ./build.sh release --arch native
+  ./build.sh dmg -v
+EOF
+    exit 0
+}
+
+log()     { echo -e "${GREEN}[✓]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
+info()    { echo -e "${CYAN}[i]${NC} $1"; }
+err()     { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+
+# ----- Parse arguments -----
+CMD="${1:-debug}"
+ARCH=""
+VERBOSE=""
+
+case "$CMD" in
+    debug|release|dmg|run|clean|help) shift ;;
+    -v|--verbose) CMD="debug"; VERBOSE="-v" ;;
+    *) usage ;;
+esac
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --arch) ARCH="$2"; shift 2 ;;
+        -v|--verbose) VERBOSE="-v"; shift ;;
+        *) usage ;;
+    esac
+done
+
+# ----- Early exit for help / clean -----
+if [ "$CMD" = "help" ]; then usage; fi
+
+if [ "$CMD" = "clean" ]; then
+    info "Cleaning build artifacts..."
+    rm -rf "$PROJECT_DIR/build" "$PROJECT_DIR/.derived"
+    xcodebuild clean -project "$PROJECT" -scheme "$SCHEME" -quiet 2>/dev/null || true
+    log "Cleaned"
+    exit 0
+fi
+
+# ----- Determine architecture -----
+CURRENT_ARCH=$(uname -m)  # arm64 or x86_64
+
+if [ -z "$ARCH" ]; then
+    case "$CMD" in
+        debug|run)  ARCH="native" ;;
+        release|dmg) ARCH="universal" ;;
+    esac
+fi
+
+case "$ARCH" in
+    native)
+        ARCH_FLAGS=()
+        ARCH_TAG="$CURRENT_ARCH"
+        ;;
+    universal)
+        ARCH_FLAGS=(-arch x86_64 -arch arm64)
+        ARCH_TAG="universal"
+        ;;
+    x86_64)
+        ARCH_FLAGS=(-arch x86_64)
+        ARCH_TAG="x86_64"
+        ;;
+    arm64)
+        ARCH_FLAGS=(-arch arm64)
+        ARCH_TAG="arm64"
+        ;;
+    *) err "Unknown arch: $ARCH (use native, universal, x86_64, arm64)" ;;
+esac
+
+# Derived build dir per arch
+BUILD_DIR="$BUILD_DIR/$ARCH_TAG"
+DERIVED_DATA="$DERIVED_DATA/$ARCH_TAG"
+
+XCODE=$(xcode-select -p 2>/dev/null) || err "Xcode not found (xcode-select -p failed)"
+
+XCB_FLAGS=(
+    -project "$PROJECT"
+    -scheme "$SCHEME"
+    -destination 'platform=macOS'
+    "${ARCH_FLAGS[@]}"
+    SYMROOT="$BUILD_DIR"
+    OBJROOT="$DERIVED_DATA"
+)
+
+# ----- Commands -----
+if [ "$CMD" = "debug" ] || [ "$CMD" = "run" ]; then
+    info "Building Debug [${ARCH_TAG}]..."
+    set -x
+    xcodebuild build "${XCB_FLAGS[@]}" \
+        -configuration Debug \
+        ${VERBOSE:+--verbose} 2>&1 | tee "$BUILD_DIR/build.log"
+    { set +x; } 2>/dev/null
+    log "Debug build succeeded → $BUILD_DIR/Debug/MacCalendar.app"
+
+    if [ "$CMD" = "run" ]; then
+        "$BUILD_DIR/Debug/MacCalendar.app/Contents/MacOS/MacCalendar" &
+        log "App launched"
+    fi
+    exit 0
+fi
+
+if [ "$CMD" = "release" ] || [ "$CMD" = "dmg" ]; then
+    info "Building Release [${ARCH_TAG}] (unsigned)..."
+    set -x
+    xcodebuild clean build "${XCB_FLAGS[@]}" \
+        -configuration Release \
+        CODE_SIGN_IDENTITY="-" \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGNING_ALLOWED=YES \
+        ${VERBOSE:+--verbose} 2>&1 | tee "$BUILD_DIR/build.log"
+    { set +x; } 2>/dev/null
+
+    APP_PATH="$BUILD_DIR/Release/MacCalendar.app"
+    [ -d "$APP_PATH" ] || err "App not found at $APP_PATH"
+
+    # Verify binary arch
+    BINARY="$APP_PATH/Contents/MacOS/MacCalendar"
+    if [ -f "$BINARY" ]; then
+        ARCHS=$(lipo -info "$BINARY" 2>/dev/null | awk -F': ' '{print $NF}')
+        log "Binary architectures: $ARCHS"
+    fi
+
+    log "Release build succeeded → $APP_PATH"
+
+    if [ "$CMD" = "dmg" ]; then
+        DMG_NAME="MacCalendar.dmg"
+        info "Creating DMG..."
+        if ! command -v create-dmg &>/dev/null; then
+            warn "create-dmg not found, installing..."
+            brew install create-dmg
+        fi
+        DMG_SRC="$BUILD_DIR/dmg_source"
+
+        rm -rf "$DMG_SRC"
+        mkdir -p "$DMG_SRC"
+        cp -r "$APP_PATH" "$DMG_SRC/"
+
+        create-dmg \
+            --volname "MacCalendar Installer" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "MacCalendar.app" 150 120 \
+            --hide-extension "MacCalendar.app" \
+            --app-drop-link 450 120 \
+            "$BUILD_DIR/$DMG_NAME" \
+            "$DMG_SRC/" 2>&1 | tee -a "$BUILD_DIR/build.log"
+
+        rm -rf "$DMG_SRC"
+        log "DMG created → $BUILD_DIR/$DMG_NAME"
+    fi
+    exit 0
+fi
+
+usage


### PR DESCRIPTION
1.修复小组件切换到别的月份很久才还原
改动前（5 分钟才还原）：

Entry 1：选中月份，显示 5 分钟
Entry 2：当前月份，5 分钟后才显示
刷新策略：.after(5 分钟后) — 导致关闭再打开仍看到旧月份
改动后（5 秒后自动还原）：

Entry 1：选中月份，显示 5 秒
生成 Entry 1 后立即重置 widgetMonthOffset 和 widgetLastUserActionTime 为 0
Entry 2：当前月份，5 秒后显示
刷新策略：.after(5 秒后) — 5 秒后刷新，此时 offset 已重置，显示当前月份

2.增加编译脚本,可选x86或arm